### PR TITLE
Fix cpp warnings

### DIFF
--- a/pyserpent.cpp
+++ b/pyserpent.cpp
@@ -151,5 +151,5 @@ static PyMethodDef PyextMethods[] = {
 
 PyMODINIT_FUNC initpyext(void)
 {
-     PyObject *m = Py_InitModule( "pyext", PyextMethods );
+     (void) Py_InitModule( "pyext", PyextMethods );
 }

--- a/rewriter.cpp
+++ b/rewriter.cpp
@@ -411,7 +411,7 @@ Node apply_rules(Node node) {
             node.args[0].val = "'" + node.args[0].val;
             i = 1;
         }
-        for (i = i; i < node.args.size(); i++) {
+        for (; i < node.args.size(); i++) {
             node.args[i] = apply_rules(node.args[i]);
         }
     }


### PR DESCRIPTION
pyserpent.cpp:154:16: warning: unused variable 'm' [-Wunused-variable]
rewriter.cpp:414:16: warning: explicitly assigning a variable of type
'unsigned int' to itself [-Wself-assign]
