### PR TITLE
Fixed a crash when parsing strings containing non-ascii characters

### DIFF
--- a/bignum.cpp
+++ b/bignum.cpp
@@ -5,9 +5,9 @@
 #include "bignum.h"
 
 //Integer to string conversion
-std::string intToDecimal(int branch) {
+std::string unsignedToDecimal(unsigned branch) {
     if (branch < 10) return nums.substr(branch, 1);
-    else return intToDecimal(branch / 10) + nums.substr(branch % 10,1);
+    else return unsignedToDecimal(branch / 10) + nums.substr(branch % 10,1);
 }
 
 //Add two strings representing decimal values
@@ -91,8 +91,8 @@ std::string decimalMod(std::string a, std::string b) {
 }
 
 //String to int conversion
-int decimalToInt(std::string a) {
+unsigned decimalToUnsigned(std::string a) {
     if (a.size() == 0) return 0;
     else return (a[a.size() - 1] - '0') 
-        + decimalToInt(a.substr(0,a.size()-1)) * 10;
+        + decimalToUnsigned(a.substr(0,a.size()-1)) * 10;
 }

--- a/bignum.h
+++ b/bignum.h
@@ -11,7 +11,7 @@ const std::string tt255 =
 "57896044618658097711785492504343953926634992332820282019728792003956564819968"
 ;
 
-std::string intToDecimal(int branch);
+std::string unsignedToDecimal(unsigned branch);
 
 std::string decimalAdd(std::string a, std::string b);
 
@@ -25,6 +25,6 @@ std::string decimalMod(std::string a, std::string b);
 
 bool decimalGt(std::string a, std::string b, bool eqAllowed=false);
 
-int decimalToInt(std::string a);
+unsigned decimalToUnsigned(std::string a);
 
 #endif

--- a/cmdline.cpp
+++ b/cmdline.cpp
@@ -96,7 +96,7 @@ int main(int argv, char** argc) {
     else if (command == "biject") {
         if (argv == 3)
              std::cerr << "Not enough arguments for biject\n";
-        int pos = decimalToInt(secondInput);
+        int pos = decimalToUnsigned(secondInput);
         std::vector<Node> n = prettyCompile(input);
         if (pos >= (int)n.size())
              std::cerr << "Code position too high\n";

--- a/rewriter.cpp
+++ b/rewriter.cpp
@@ -344,7 +344,7 @@ Node subst(Node pattern,
 
 Node array_lit_transform(Node node) {
     std::vector<Node> o1;
-    o1.push_back(token(intToDecimal(node.args.size() * 32), node.metadata));
+    o1.push_back(token(unsignedToDecimal(node.args.size() * 32), node.metadata));
     std::vector<Node> o2;
     std::string symb = "_temp"+mkUniqueToken()+"_0";
     o2.push_back(token(symb, node.metadata));
@@ -357,7 +357,7 @@ Node array_lit_transform(Node node) {
         o5.push_back(token(symb, node.metadata));
         std::vector<Node> o6;
         o6.push_back(astnode("get", o5, node.metadata));
-        o6.push_back(token(intToDecimal(i * 32), node.metadata));
+        o6.push_back(token(unsignedToDecimal(i * 32), node.metadata));
         std::vector<Node> o7;
         o7.push_back(astnode("add", o6));
         o7.push_back(node.args[i]);
@@ -479,10 +479,10 @@ Node validate(Node inp) {
         int i = 0;
         while(valid[i][0] != "---END---") {
             if (inp.val == valid[i][0]) {
-                if (decimalGt(valid[i][1], intToDecimal(inp.args.size()))) {
+                if (decimalGt(valid[i][1], unsignedToDecimal(inp.args.size()))) {
                     err("Too few arguments for "+inp.val, inp.metadata);   
                 }
-                if (decimalGt(intToDecimal(inp.args.size()), valid[i][2])) {
+                if (decimalGt(unsignedToDecimal(inp.args.size()), valid[i][2])) {
                     err("Too many arguments for "+inp.val, inp.metadata);   
                 }
             }

--- a/util.cpp
+++ b/util.cpp
@@ -60,8 +60,8 @@ std::string printAST(Node ast, bool printMetadata) {
     std::string o = "(";
     if (printMetadata) {
          o += ast.metadata.file + " ";
-         o += intToDecimal(ast.metadata.ln) + " ";
-         o += intToDecimal(ast.metadata.ch) + ": ";
+         o += unsignedToDecimal(ast.metadata.ln) + " ";
+         o += unsignedToDecimal(ast.metadata.ch) + ": ";
     }
     o += ast.val;
     std::vector<std::string> subs;
@@ -132,14 +132,14 @@ std::string strToNumeric(std::string inp) {
     else if ((inp[0] == '"' && inp[inp.length()-1] == '"')
             || (inp[0] == '\'' && inp[inp.length()-1] == '\'')) {
 		for (unsigned i = 1; i < inp.length() - 1; i++) {
-            o = decimalAdd(decimalMul(o,"256"), intToDecimal(inp[i]));
+            o = decimalAdd(decimalMul(o,"256"), unsignedToDecimal((unsigned char)inp[i]));
         }
     }
     else if (inp.substr(0,2) == "0x") {
 		for (unsigned i = 2; i < inp.length(); i++) {
             int dig = std::string("0123456789abcdef").find(inp[i]);
             if (dig < 0) return "";
-            o = decimalAdd(decimalMul(o,"16"), intToDecimal(dig));
+            o = decimalAdd(decimalMul(o,"16"), unsignedToDecimal(dig));
         }
     }
     else {
@@ -188,7 +188,7 @@ int counter = 0;
 //Makes a unique token
 std::string mkUniqueToken() {
     counter++;
-    return intToDecimal(counter);
+    return unsignedToDecimal(counter);
 }
 
 //Does a file exist? http://stackoverflow.com/questions/12774207
@@ -217,7 +217,7 @@ std::string get_file_contents(std::string filename)
 //Report error
 void err(std::string errtext, Metadata met) {
     std::string err = "Error (file \"" + met.file + "\", line " +
-        intToDecimal(met.ln) + ", char " + intToDecimal(met.ch) +
+        unsignedToDecimal(met.ln) + ", char " + unsignedToDecimal(met.ch) +
         "): " + errtext;
     std::cerr << err << "\n";
     throw(err);


### PR DESCRIPTION
How to reproduce:

```
echo a = \"però\" | ./serpent -s compile
```

The problem was caused by a negative number being passed to `intToDecimal()` from `strToNumeric()`.
I fixed it by casting to unsigned char.

But then I noticed that the way `intToDecimal()` is implemented and used makes no sense with a signed int argument to begin with: therefore I changed `intToDecimal()` and its counterpart `decimalToInt()` into `unsignedToDecimal()` and `decimalToUnsigned()` in order to clarify what kind of integers we are expecting.
