### PR TITLE
Left sided string, fixing inconsistency with Alethzero(#5)

### DIFF
--- a/util.cpp
+++ b/util.cpp
@@ -131,8 +131,14 @@ std::string strToNumeric(std::string inp) {
     }
     else if ((inp[0] == '"' && inp[inp.length()-1] == '"')
             || (inp[0] == '\'' && inp[inp.length()-1] == '\'')) {
-		for (unsigned i = 1; i < inp.length() - 1; i++) {
+        for (unsigned i = 1; i < inp.length() - 1; i++) {
             o = decimalAdd(decimalMul(o,"256"), unsignedToDecimal((unsigned char)inp[i]));
+        }
+        // Right-pad.
+        if( inp.length() < 32 ) {
+            for (unsigned i = 1; i < 32 - inp.length() - 1; i++) {
+                o = decimalMul(o,"256");
+            }
         }
     }
     else if (inp.substr(0,2) == "0x") {

--- a/util.cpp
+++ b/util.cpp
@@ -131,12 +131,13 @@ std::string strToNumeric(std::string inp) {
     }
     else if ((inp[0] == '"' && inp[inp.length()-1] == '"')
             || (inp[0] == '\'' && inp[inp.length()-1] == '\'')) {
+        //(Iterate excluding quotation marks.
         for (unsigned i = 1; i < inp.length() - 1; i++) {
             o = decimalAdd(decimalMul(o,"256"), unsignedToDecimal((unsigned char)inp[i]));
         }
         // Right-pad.
-        if( inp.length() < 32 ) {
-            for (unsigned i = 1; i < 32 - inp.length() - 1; i++) {
+        if( inp.length() < 34 ) {
+            for (unsigned i = 0 ; i < 32 - (inp.length() - 2); i++) {
                 o = decimalMul(o,"256");
             }
         }


### PR DESCRIPTION
Right-padding instead of left padding.. Looks like the pyethereum tester has a string conversion too, so that'd need a little change too.

Oh, looks like `serpent.encode_data` and `serpent.decode_data` need some modification aswel. Although maybe the tester itself should expose some such. I tested it with my own encode and decoder on some of my projects.([1](https://github.com/o-jasper/o-jasper.github.io/tree/master/eth-entity/assurance_entity), [2](https://github.com/o-jasper/o-jasper.github.io/tree/master/eth-entity/grudge_escrow))

Develop branch is old, so i sent it to master.
