### PR TITLE
Python3 support

### DIFF
--- a/pyserpent.cpp
+++ b/pyserpent.cpp
@@ -6,6 +6,12 @@
 #include <iostream>
 #include "funcs.h"
 
+#if PY_MAJOR_VERSION >= 3
+#define PY_STRING_FORMAT "y#"
+#else
+#define PY_STRING_FORMAT "s#"
+#endif
+
 #define PYMETHOD(name, FROM, method, TO) \
     static PyObject * name(PyObject *, PyObject *args) { \
         try { \
@@ -21,7 +27,7 @@
 #define FROMSTR(v) \
     const char *command; \
     int len; \
-    if (!PyArg_ParseTuple(args, "s#", &command, &len)) \
+    if (!PyArg_ParseTuple(args, PY_STRING_FORMAT, &command, &len)) \
         return NULL; \
     std::string v = std::string(command, len); \
 
@@ -40,7 +46,7 @@
 // Convert metadata into python wrapper form [file, ln, ch]
 PyObject* pyifyMetadata(Metadata m) {
     PyObject* a = PyList_New(0);
-    PyList_Append(a, Py_BuildValue("s#", m.file.c_str(), m.file.length()));
+    PyList_Append(a, Py_BuildValue(PY_STRING_FORMAT, m.file.c_str(), m.file.length()));
     PyList_Append(a, Py_BuildValue("i", m.ln));
     PyList_Append(a, Py_BuildValue("i", m.ch));
     return a;
@@ -51,7 +57,7 @@ PyObject* pyifyMetadata(Metadata m) {
 PyObject* pyifyNode(Node n) {
     PyObject* a = PyList_New(0);
     PyList_Append(a, Py_BuildValue("i", n.type == ASTNODE));
-    PyList_Append(a, Py_BuildValue("s#", n.val.c_str(), n.val.length()));
+    PyList_Append(a, Py_BuildValue(PY_STRING_FORMAT, n.val.c_str(), n.val.length()));
     PyList_Append(a, pyifyMetadata(n.metadata));
     for (unsigned i = 0; i < n.args.size(); i++)
         PyList_Append(a, pyifyNode(n.args[i]));
@@ -60,7 +66,7 @@ PyObject* pyifyNode(Node n) {
 
 // Convert string into python wrapper form
 PyObject* pyifyString(std::string s) {
-    return Py_BuildValue("s#", s.c_str(), s.length());
+    return Py_BuildValue(PY_STRING_FORMAT, s.c_str(), s.length());
 }
 
 // Convert list of nodes into python wrapper form
@@ -82,7 +88,11 @@ int cppifyInt(PyObject* o) {
 // Convert pyobject string into normal form
 std::string cppifyString(PyObject* o) {
     const char *command;
+#if PY_MAJOR_VERSION >= 3
+    if (!PyArg_Parse(o, "y", &command))
+#else
     if (!PyArg_Parse(o, "s", &command))
+#endif
         err("Argument should be string", Metadata());
     return std::string(command);
 }
@@ -167,7 +177,22 @@ static PyMethodDef PyextMethods[] = {
     {NULL, NULL, 0, NULL}        /* Sentinel */
 };
 
+#if PY_MAJOR_VERSION >= 3
+static struct PyModuleDef SerpentModule = {
+    PyModuleDef_HEAD_INIT,
+    "serpent_pyext",
+    "...",
+    -1,
+    PyextMethods
+};
+
+PyMODINIT_FUNC PyInit_serpent_pyext(void) {
+    return PyModule_Create(&SerpentModule);
+}
+
+#else
 PyMODINIT_FUNC initserpent_pyext(void)
 {
      Py_InitModule( "serpent_pyext", PyextMethods );
 }
+#endif

--- a/serpent.py
+++ b/serpent.py
@@ -1,9 +1,15 @@
 import serpent_pyext as pyext
 import sys
 import re
+import binascii
 
 VERSION = '1.6.7'
 
+def strtobytes(x):
+    return x.encode('ascii') if isinstance(x, str) else x
+
+def bytestostr(x):
+    return x.decode('ascii') if isinstance(x, bytes) else x
 
 class Metadata(object):
     def __init__(self, li):
@@ -24,7 +30,7 @@ class Token(object):
         return [0, self.val, self.metadata.out()]
 
     def __repr__(self):
-        return str(self.val)
+        return str(bytestostr(self.val))
 
 
 class Astnode(object):
@@ -38,18 +44,18 @@ class Astnode(object):
         return o
 
     def __repr__(self):
-        o = '(' + self.val
-        subs = map(repr, self.args)
+        o = '(' + bytestostr(self.val)
+        subs = list(map(repr, self.args))
         k = 0
         out = " "
         while k < len(subs) and o != "(seq":
             if '\n' in subs[k] or len(out + subs[k]) >= 80:
                 break
-            out += subs[k] + " "
+            out += bytestostr(subs[k]) + " "
             k += 1
         if k < len(subs):
             o += out + "\n  "
-            o += '\n  '.join('\n'.join(subs[k:]).split('\n'))
+            o += '\n  '.join('\n'.join(map(bytestostr, subs[k:])).split('\n'))
             o += '\n)'
         else:
             o += out[:-1] + ')'
@@ -64,26 +70,25 @@ def node(li):
 
 
 def take(x):
-    return pyext.parse_lll(x) if isinstance(x, (str, unicode)) else x.out()
+    return pyext.parse_lll(x) if isinstance(x, (str, unicode, bytes)) else x.out()
 
 
 def takelist(x):
-    return map(take, parse(x).args if isinstance(x, (str, unicode)) else x)
+    return map(take, parse(x).args if isinstance(x, (str, unicode, bytes)) else x)
 
-
-compile = lambda x: pyext.compile(x)
-compile_chunk = lambda x: pyext.compile_chunk(x)
-compile_to_lll = lambda x: node(pyext.compile_to_lll(x))
-compile_chunk_to_lll = lambda x: node(pyext.compile_chunk_to_lll(x))
-compile_lll = lambda x: pyext.compile_lll(take(x))
-parse = lambda x: node(pyext.parse(x))
-rewrite = lambda x: node(pyext.rewrite(take(x)))
-rewrite_chunk = lambda x: node(pyext.rewrite_chunk(take(x)))
-pretty_compile = lambda x: map(node, pyext.pretty_compile(x))
-pretty_compile_chunk = lambda x: map(node, pyext.pretty_compile_chunk(x))
-pretty_compile_lll = lambda x: map(node, pyext.pretty_compile_lll(take(x)))
-serialize = lambda x: pyext.serialize(takelist(x))
-deserialize = lambda x: map(node, pyext.deserialize(x))
+compile = lambda x: pyext.compile(strtobytes(x))
+compile_chunk = lambda x: pyext.compile_chunk(strtobytes(x))
+compile_to_lll = lambda x: node(pyext.compile_to_lll(strtobytes(x)))
+compile_chunk_to_lll = lambda x: node(pyext.compile_chunk_to_lll(strtobytes(x)))
+compile_lll = lambda x: pyext.compile_lll(take(strtobytes(x)))
+parse = lambda x: node(pyext.parse(strtobytes(x)))
+rewrite = lambda x: node(pyext.rewrite(take(strtobytes(x))))
+rewrite_chunk = lambda x: node(pyext.rewrite_chunk(take(strtobytes(x))))
+pretty_compile = lambda x: map(node, pyext.pretty_compile(strtobytes(x)))
+pretty_compile_chunk = lambda x: map(node, pyext.pretty_compile_chunk(strtobytes(x)))
+pretty_compile_lll = lambda x: map(node, pyext.pretty_compile_lll(take(strtobytes(x))))
+serialize = lambda x: pyext.serialize(takelist(strtobytes(x)))
+deserialize = lambda x: map(node, pyext.deserialize(strtobytes(x)))
 
 is_numeric = lambda x: isinstance(x, (int, long))
 is_string = lambda x: isinstance(x, (str, unicode))
@@ -148,7 +153,7 @@ def decode_datalist(arr):
 
 def main():
     if len(sys.argv) == 1:
-        print "serpent <command> <arg1> <arg2> ..."
+        print("serpent <command> <arg1> <arg2> ...")
     else:
         cmd = sys.argv[2] if sys.argv[1] == '-s' else sys.argv[1]
         if sys.argv[1] == '-s':
@@ -156,13 +161,13 @@ def main():
             if cmd == 'deserialize':
                 args[0] = args[0].strip().decode('hex')
         elif sys.argv[1] == '-v':
-            print VERSION
+            print(VERSION)
             sys.exit()
         else:
             cmd = sys.argv[1]
             args = sys.argv[2:]
         o = globals()[cmd](*args)
         if isinstance(o, (Token, Astnode, list)):
-            print repr(o)
+            print(repr(o))
         else:
-            print o.encode('hex')
+            print(binascii.b2a_hex(o).decode('ascii'))


### PR DESCRIPTION
This allows serpent_pyext to be used in python3, keeping python2 compatibility.
In python3 all module methods take `bytes` input and produce `bytes` output where `str` is used in python2   

ref ethereum/pyethereum/issues/132, ethereum/pyethereum/issues/188