### PR TITLE
Python3 support

### DIFF
--- a/serpent.py
+++ b/serpent.py
@@ -1,8 +1,14 @@
 import serpent_pyext as pyext
 import sys, re
+import binascii
 
 VERSION = '1.8.0'
 
+def strtobytes(x):
+    return x.encode('ascii') if isinstance(x, str) else x
+
+def bytestostr(x):
+    return x.decode('ascii') if isinstance(x, bytes) else x
 
 class Metadata(object):
     def __init__(self, li):
@@ -23,7 +29,7 @@ class Token(object):
         return [0, self.val, self.metadata.out()]
 
     def __repr__(self):
-        return str(self.val)
+        return str(bytestostr(self.val))
 
 
 class Astnode(object):
@@ -37,8 +43,8 @@ class Astnode(object):
         return o
 
     def __repr__(self):
-        o = '(' + self.val
-        subs = map(repr, self.args)
+        o = '(' + bytestostr(self.val)
+        subs = list(map(bytestostr, map(repr, self.args)))
         k = 0
         out = " "
         while k < len(subs) and o != "(seq":
@@ -63,24 +69,28 @@ def node(li):
 
 
 def take(x):
-    return pyext.parse_lll(x) if isinstance(x, (str, unicode)) else x.out()
-
+    if sys.version_info[0] < 3:
+        return pyext.parse_lll(x) if isinstance(x, (str, unicode)) else x.out()
+    else:
+        return pyext.parse_lll(x) if isinstance(x, (str, bytes)) else x.out()
 
 def takelist(x):
-    return map(take, parse(x).args if isinstance(x, (str, unicode)) else x)
+    if sys.version_info[0] < 3:
+        return map(take, parse(x).args if isinstance(x, (str, unicode)) else x)
+    else:
+        return map(take, parse(x).args if isinstance(x, (str, bytes)) else x)
 
-
-compile = lambda x: pyext.compile(x)
-compile_to_lll = lambda x: node(pyext.compile_to_lll(x))
-compile_lll = lambda x: pyext.compile_lll(take(x))
-parse = lambda x: node(pyext.parse(x))
-rewrite = lambda x: node(pyext.rewrite(take(x)))
-pretty_compile = lambda x: map(node, pyext.pretty_compile(x))
-pretty_compile_lll = lambda x: map(node, pyext.pretty_compile_lll(take(x)))
-serialize = lambda x: pyext.serialize(takelist(x))
-deserialize = lambda x: map(node, pyext.deserialize(x))
-mk_signature = lambda x: pyext.mk_signature(x)
-mk_full_signature = lambda x: pyext.mk_full_signature(x)
+compile = lambda x: pyext.compile(strtobytes(x))
+compile_to_lll = lambda x: node(pyext.compile_to_lll(strtobytes(x)))
+compile_lll = lambda x: pyext.compile_lll(take(strtobytes(x)))
+parse = lambda x: node(pyext.parse(strtobytes(x)))
+rewrite = lambda x: node(pyext.rewrite(take(strtobytes(x))))
+pretty_compile = lambda x: map(node, pyext.pretty_compile(strtobytes(x)))
+pretty_compile_lll = lambda x: map(node, pyext.pretty_compile_lll(take(strtobytes(x))))
+serialize = lambda x: pyext.serialize(takelist(strtobytes(x)))
+deserialize = lambda x: map(node, pyext.deserialize(strtobytes(x)))
+mk_signature = lambda x: pyext.mk_signature(strtobytes(x))
+mk_full_signature = lambda x: pyext.mk_full_signature(strtobytes(x))
 get_prefix = lambda x, y: pyext.get_prefix(x, y) % 2**32
 
 is_numeric = lambda x: isinstance(x, (int, long))
@@ -168,13 +178,13 @@ def decode_abi(arr, *lens):
 
 def main():
     if len(sys.argv) == 1:
-        print "serpent <command> <arg1> <arg2> ..."
+        print("serpent <command> <arg1> <arg2> ...")
     else:
         cmd = sys.argv[2] if sys.argv[1] == '-s' else sys.argv[1]
         if sys.argv[1] == '-s':
             args = [sys.stdin.read()] + sys.argv[3:]
         elif sys.argv[1] == '-v':
-            print VERSION
+            print(VERSION)
             sys.exit()
         else:
             cmd = sys.argv[1]
@@ -186,8 +196,8 @@ def main():
             kwargs['source'] = 'cmdline'
         o = globals()[cmd](*args, **kwargs)
         if isinstance(o, (Token, Astnode, list)):
-            print repr(o)
+            print(repr(o))
         elif cmd in ['mk_signature', 'mk_full_signature', 'get_prefix']:
-            print o
+            print(o)
         else:
-            print o.encode('hex')
+            print(binascii.b2a_hex(o).decode('ascii'))


### PR DESCRIPTION
This allows serpent_pyext to be used in python3, keeping python2 compatibility.
In python3 all module methods take `bytes` input and produce `bytes` output where `str` is used in python2

ref ethereum/pyethereum#132, ethereum/pyethereum#188