### PR TITLE
Fix pretty_compile command

### DIFF
--- a/serpent.py
+++ b/serpent.py
@@ -235,5 +235,7 @@ def main():
             print(json.dumps(json.loads(o)))
         elif cmd in ['mk_signature', 'get_prefix']:
             print(o)
+        elif cmd in ['pretty_compile']:
+            print(list(o))
         else:
             print(binascii.b2a_hex(o).decode('ascii'))


### PR DESCRIPTION
I followed the tutorial from the github wiki page.  There was a problem when I got to pretty_compile.

```
$ serpent pretty_compile mul2.se
Traceback (most recent call last):
  File "/usr/local/var/pyenv/versions/ethereum/bin/serpent", line 9, in <module>
    load_entry_point('ethereum-serpent==2.0.2', 'console_scripts', 'serpent')()
...
    print(binascii.b2a_hex(o).decode('ascii'))
TypeError: a bytes-like object is required, not 'map'
```

This has a trivial fix, but I couldn't run the test suite.
