### PR TITLE
Fix decimalGt declaration to match the implementation

### DIFF
--- a/bignum.h
+++ b/bignum.h
@@ -3,11 +3,11 @@
 
 const std::string nums = "0123456789";
 
-const std::string tt256 = 
+const std::string tt256 =
 "115792089237316195423570985008687907853269984665640564039457584007913129639936"
 ;
 
-const std::string tt256m1 = 
+const std::string tt256m1 =
 "115792089237316195423570985008687907853269984665640564039457584007913129639935"
 ;
 
@@ -33,7 +33,7 @@ std::string decimalModExp(std::string b, std::string e, std::string m);
 
 std::string decimalExp(std::string b, std::string e);
 
-bool decimalGt(std::string a, std::string b, bool eqAllowed=false);
+bool decimalGt(const std::string &a, const std::string &b, bool eqAllowed=false);
 
 unsigned decimalToUnsigned(const std::string &a);
 


### PR DESCRIPTION
`decimalGt` in the header was declared taking `std::string` by value, whereas the implementation was (correctly) using `const std::string&`.