### PR TITLE
Fixed ecc tests (except --ringsig) by adding uint256 type annotations

### DIFF
--- a/examples/ecc/ecrecover.se
+++ b/examples/ecc/ecrecover.se
@@ -1,10 +1,10 @@
-# So I looked up on Wikipedia what Jacobian form actually is, and noticed that it's 
+# So I looked up on Wikipedia what Jacobian form actually is, and noticed that it's
 # actually a rather different and more clever construction than the naive version
-# that I created. It may possible to achieve a further 20-50% savings by applying 
+# that I created. It may possible to achieve a further 20-50% savings by applying
 # that version.
 
-extern modint.type: [add:[int256,int256,int256,int256,int256,int256]:int256[], decompose:[int256[]]:int256[], double:[int256,int256,int256]:int256[], exp:[int256,int256,int256]:int256, mul:[int256,int256,int256,int256]:int256[], recover_y:[int256,int256]:int256]
-extern modexp.se: [exp:[int256,int256,int256]:int256]
+extern modint.type: [add:[uint256,uint256,uint256,uint256,uint256,uint256]:uint256[], decompose:[int256[]]:int256[], double:[uint256,uint256,uint256]:uint256[], exp:[uint256,uint256,uint256]:uint256, mul:[uint256,uint256,uint256,uint256]:uint256[], recover_y:[uint256,int256]:int256]
+extern modexp.se: [exp:[uint256,uint256,uint256]:uint256]
 
 data JACOBIAN_ARITH
 data EXP
@@ -17,7 +17,7 @@ def init():
 
 event PubkeyTripleLogEvent(x:uint256, y:uint256, z:uint256)
 
-def ecrecover(h, v, r, s):
+def ecrecover(h:uint256, v, r:uint256, s:int256):
     h = mod(h, N)
     r = mod(r, P)
     s = mod(s, N)

--- a/examples/ecc/jacobian_arith.se
+++ b/examples/ecc/jacobian_arith.se
@@ -1,6 +1,6 @@
 inset('modint.type')
 
-def double(m_ax, m_ay, m_az):
+def double(m_ax:uint256, m_ay:uint256, m_az:uint256):
     if !m_ay:
         return([0, 0, 0]:arr)
     with P_______P = -4294968273:
@@ -18,7 +18,7 @@ def double(m_ax, m_ay, m_az):
                                         ~mstore(~msize(), m_nz)
                                         return((~msize() - 96):arr)
 
-def add(m_ax, m_ay, m_az, m_bx, m_by, m_bz):
+def add(m_ax:uint256, m_ay:uint256, m_az:uint256, m_bx:uint256, m_by:uint256, m_bz:uint256):
     if !m_ay:
         return([m_bx, m_by, m_bz]:arr)
     if !m_by:
@@ -48,7 +48,7 @@ def add(m_ax, m_ay, m_az, m_bx, m_by, m_bz):
                                                         return((~msize() - 96):arr)
 
 
-def mul(m_bx, m_by, m_bz, n):
+def mul(m_bx:uint256, m_by:uint256, m_bz:uint256, n:uint256):
     n = mod(n, -432420386565659656852420866394968145599)
     if !m_bx * !m_by + !n: # Constant-gas version of !axn and !ayn or !n
         return([0, 0, 1]:arr)
@@ -100,7 +100,7 @@ def mul(m_bx, m_by, m_bz, n):
             return(o:arr)
 
 
-def recover_y(x, y_bit):
+def recover_y(x:uint256, y_bit):
     N = -432420386565659656852420866394968145599
     P = -4294968273
     xcubed = mulmod(mulmod(x, x, P), x, P)
@@ -109,7 +109,7 @@ def recover_y(x, y_bit):
     return(beta * y_is_positive + (P - beta) * (1 - y_is_positive))
 
 
-def exp(b, e, m):
+def exp(b:uint256, e:uint256, m:uint256):
     with o = 1:
         with bit = 2 ^ 255:
             while gt(bit, 0):

--- a/examples/ecc/modexp.se
+++ b/examples/ecc/modexp.se
@@ -1,4 +1,4 @@
-def exp(b, e, m):
+def exp(b:uint256, e:uint256, m:uint256):
     with o = 1:
         with bit = 2 ^ 255:
             while gt(bit, 0):


### PR DESCRIPTION
Tests were failing in the ABI check when encoding the arguments to `ecrecover`: the hash value starts with `0xf`, resulting in a negative `int256`. Changing the type to `uint256` (including a few other changes) makes the ABI checks happy.
