### PR TITLE
Fix setup on pypy which doesn't export OPT env

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -4,9 +4,10 @@ import os
 from distutils.sysconfig import get_config_vars
 
 (opt,) = get_config_vars('OPT')
-os.environ['OPT'] = " ".join(
-    flag for flag in opt.split() if flag != '-Wstrict-prototypes'
-)
+if opt is not None:
+    os.environ['OPT'] = " ".join(
+        flag for flag in opt.split() if flag != '-Wstrict-prototypes'
+    )
 
 setup(
     # Name of this package


### PR DESCRIPTION
This change enables install on `pypy` which doesn't export `OPT` env var.